### PR TITLE
Add handle root option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,16 @@ export const PostList = (props) => (
 
 ```
 
+## Options
+
+### Customize root path of the resource
+
+The default is to target resources under the `app/` directory. if there is a program for the server, such as an API root, specify `handleRoot` to avoid it.
+
+```js
+// Change the default directory of handleRoot from `app/`.
+const dataProvider = blitzDataProvider({ invoke, searchEntities, handleRoot: 'app/reactAdmin' });
+```
+
 ##  License
 This data provider is licensed under the MIT License.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@ import { getHandler } from './utils/getHandler';
 import { mapFilters } from './utils/mapFilters';
 import { mapPaginationAndSort } from './utils/mapPaginationAndSort';
 
-const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParams): DataProvider => ({
+const getBlitzDataProvider = ({ invoke, searchEntities, handlerRoot = 'app' }: BlitzDataProviderParams): DataProvider => ({
   getList: async (resource, params) => {
-    const handler = await getHandler({ resource, plural: true, invoke });
+    const handler = await getHandler({ handlerRoot, resource, plural: true, invoke });
     const data = await handler({ ...mapPaginationAndSort(params), ...mapFilters(params, resource, searchEntities) });
     return {
       data: data[resource],
@@ -16,7 +16,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
 
   getOne: async (resource, params) => {
     const id = params.id as string;
-    const handler = await getHandler({ resource, invoke });
+    const handler = await getHandler({ handlerRoot, resource, invoke });
     const data = await handler({ id: parseInt(id) });
     return {
       data,
@@ -24,7 +24,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
   },
 
   getMany: async (resource, params) => {
-    const handler = await getHandler({ resource, plural: true, invoke });
+    const handler = await getHandler({ handlerRoot, resource, plural: true, invoke });
     const data = await handler({
       where: {
         id: {
@@ -39,7 +39,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
   },
 
   getManyReference: async (resource, params) => {
-    const handler = await getHandler({ resource, plural: true, invoke });
+    const handler = await getHandler({ handlerRoot, resource, plural: true, invoke });
     const data = await handler({
       ...mapPaginationAndSort(params),
       where: {
@@ -54,7 +54,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
   },
 
   update: async (resource, params) => {
-    const handler = await getHandler({ resource, method: QueryMethod.Update, invoke });
+    const handler = await getHandler({ handlerRoot, resource, method: QueryMethod.Update, invoke });
     const data = await handler({
       id: params.id,
       ...params.data,
@@ -67,6 +67,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
     const responses = await Promise.all(
       params.ids.map(async id => {
         const handler = await getHandler({
+          handlerRoot,
           resource,
           method: QueryMethod.Update,
           invoke,
@@ -81,7 +82,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
   },
 
   create: async (resource, params) => {
-    const handler = await getHandler({ resource, method: QueryMethod.Create, invoke });
+    const handler = await getHandler({ handlerRoot, resource, method: QueryMethod.Create, invoke });
     const data = await handler(params.data);
 
     return {
@@ -90,7 +91,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
   },
 
   delete: async (resource, params) => {
-    const handler = await getHandler({ resource, method: QueryMethod.Delete, invoke });
+    const handler = await getHandler({ handlerRoot, resource, method: QueryMethod.Delete, invoke });
     const data = await handler({
       id: params.id,
     });
@@ -102,6 +103,7 @@ const getBlitzDataProvider = ({ invoke, searchEntities }: BlitzDataProviderParam
     const responses = await Promise.all(
       params.ids.map(async id => {
         const handler = await getHandler({
+          handlerRoot,
           resource,
           method: QueryMethod.Delete,
           invoke,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export enum QueryMethod {
 }
 
 export type GetHandlerModuleParams = {
+  handlerRoot: string;
   resource: string;
   method?: QueryMethod;
   plural?: boolean;
@@ -14,6 +15,7 @@ export type GetHandlerModuleParams = {
 export type BlitzDataProviderParams = {
   invoke: (module: any, params: any) => any;
   searchEntities: (q: string) => any;
+  handlerRoot?: string;
 };
 
 export type GetHandlerParams = GetHandlerModuleParams & Pick<BlitzDataProviderParams, 'invoke'>;

--- a/src/utils/getHandler.test.ts
+++ b/src/utils/getHandler.test.ts
@@ -4,19 +4,25 @@ import { getHandler } from './getHandler';
 describe('getHandler', () => {
   it('should not throw for valid resource and methods', async () => {
     for (const method of Object.values(QueryMethod)) {
-      await expect(getHandler({ resource: 'posts', method, invoke: global.mockedInvoke })).resolves.not.toThrow();
+      await expect(getHandler({ handlerRoot: 'app', resource: 'posts', method, invoke: global.mockedInvoke })).resolves.not.toThrow();
     }
+  });
+
+  it('should not throw for handle root of the resource is specified', async () => {
+    await expect(
+      getHandler({ handlerRoot: 'app/reactAdmin', resource: 'posts', method: QueryMethod.Get, invoke: global.mockedInvoke }),
+    ).resolves.not.toThrow();
   });
 
   it('should throw error for non existing resource', async () => {
     await expect(
-      getHandler({ resource: 'non-existing', method: QueryMethod.Get, invoke: global.mockedInvoke }),
+      getHandler({ handlerRoot: 'app', resource: 'non-existing', method: QueryMethod.Get, invoke: global.mockedInvoke }),
     ).rejects.toThrow();
   });
 
   it('should throw error for non plural resource', async () => {
     await expect(
-      getHandler({ resource: 'post', method: QueryMethod.Get, invoke: global.mockedInvoke }),
+      getHandler({ handlerRoot: 'app', resource: 'post', method: QueryMethod.Get, invoke: global.mockedInvoke }),
     ).rejects.toThrowError(`Resource 'post' MUST be plural!`);
   });
 });

--- a/src/utils/getHandler.ts
+++ b/src/utils/getHandler.ts
@@ -3,18 +3,18 @@ import { QueryMethod, GetHandlerParams, GetHandlerModuleParams } from '../types'
 import { getEntityNameFromResource } from './getEntityNameFromResource';
 import { getPluralEntityName } from './getPluralEntityName';
 
-const getHandlerModule = async ({ resource, method, plural }: GetHandlerModuleParams) => {
+const getHandlerModule = async ({ handlerRoot, resource, method, plural }: GetHandlerModuleParams) => {
   const entityName = getEntityNameFromResource(resource);
   const folder = method === QueryMethod.Get ? 'queries' : 'mutations';
-  return import(`app/${resource}/${folder}/${method}${plural ? getPluralEntityName(entityName) : entityName}`);
+  return import(`${handlerRoot}/${resource}/${folder}/${method}${plural ? getPluralEntityName(entityName) : entityName}`);
 };
 
-export const getHandler = async ({ resource, method = QueryMethod.Get, plural = false, invoke }: GetHandlerParams) => {
+export const getHandler = async ({ handlerRoot, resource, method = QueryMethod.Get, plural = false, invoke }: GetHandlerParams) => {
   if (!isPlural(resource)) {
     throw new Error(`Resource '${resource}' MUST be plural!`);
   }
 
-  const handlerModule = await getHandlerModule({ resource, method, plural });
+  const handlerModule = await getHandlerModule({ handlerRoot, resource, method, plural });
 
   return async (params: any) => invoke(handlerModule.default, params);
 };

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,6 +5,7 @@ jest.mock('app/posts/queries/getPosts', () => () => ({ posts: [], count: 0 }), {
 jest.mock('app/posts/mutations/createPost', () => () => ({}), { virtual: true });
 jest.mock('app/posts/mutations/updatePost', () => () => ({}), { virtual: true });
 jest.mock('app/posts/mutations/deletePost', () => () => ({}), { virtual: true });
+jest.mock('app/reactAdmin/posts/queries/getPost', () => () => ({}), { virtual: true });
 
 global.mockedInvoke = jest.fn(async (handler, params) => {
   return handler(params);


### PR DESCRIPTION
The default is to target resources under the `app/` directory, but if there is a program for the server such as API root, specify `handleRoot` to avoid it.(#3)